### PR TITLE
Improve missing input video guidance in pipeline scripts

### DIFF
--- a/python-be/inputs/README.md
+++ b/python-be/inputs/README.md
@@ -1,0 +1,15 @@
+# Input video placeholder
+
+Place your source footage in this folder and rename it to `input.mp4` before running `run_all.sh` or `run_all.bat`.
+
+You can also pass an absolute or relative path to the scripts:
+
+```bash
+./run_all.sh path/to/your/video.mp4
+```
+
+```bat
+run_all.bat path\to\your\video.mp4
+```
+
+The pipeline will create `outputs/` and copy processed assets into `public/input/` automatically.

--- a/python-be/run_all.bat
+++ b/python-be/run_all.bat
@@ -4,8 +4,11 @@ setlocal ENABLEEXTENSIONS
 set "SCRIPT_DIR=%~dp0"
 cd /d "%SCRIPT_DIR%"
 
+set "INPUT_DIR=%SCRIPT_DIR%inputs"
+if not exist "%INPUT_DIR%" mkdir "%INPUT_DIR%"
+
 set "SOURCE_VIDEO=%~1"
-if "%SOURCE_VIDEO%"=="" set "SOURCE_VIDEO=inputs\input.mp4"
+if "%SOURCE_VIDEO%"=="" set "SOURCE_VIDEO=%INPUT_DIR%\input.mp4"
 
 set "OUTPUT_DIR=%SCRIPT_DIR%outputs"
 set "PUBLIC_ROOT=%SCRIPT_DIR%..\public"
@@ -17,6 +20,8 @@ set "PLAN_MAPPING=%SCRIPT_DIR%plan\mapping.json"
 
 if not exist "%SOURCE_VIDEO%" (
   echo [ERROR] Khong tim thay video dau vao: %SOURCE_VIDEO%
+  echo         - Dat video nguon tai: %INPUT_DIR%\input.mp4
+  echo         - Hoac chay: run_all.bat duongdan\den\video.mp4
   exit /b 1
 )
 

--- a/python-be/run_all.sh
+++ b/python-be/run_all.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-SOURCE_VIDEO="${1:-inputs/input.mp4}"
+INPUT_DIR="$SCRIPT_DIR/inputs"
+DEFAULT_SOURCE_VIDEO="$INPUT_DIR/input.mp4"
+SOURCE_VIDEO="${1:-$DEFAULT_SOURCE_VIDEO}"
 OUTPUT_DIR="$SCRIPT_DIR/outputs"
 PUBLIC_ROOT="$SCRIPT_DIR/../public"
 PUBLIC_INPUT="$PUBLIC_ROOT/input"
@@ -13,8 +15,12 @@ WHISPER_SRT="$OUTPUT_DIR/stage1_cut.srt"
 PLAN_TMP="$OUTPUT_DIR/plan.json"
 PLAN_MAPPING="$SCRIPT_DIR/plan/mapping.json"
 
+mkdir -p "$INPUT_DIR"
+
 if [ ! -f "$SOURCE_VIDEO" ]; then
   echo "[ERROR] Không tìm thấy video đầu vào: $SOURCE_VIDEO" >&2
+  echo "        - Đặt video nguồn tại: $INPUT_DIR/input.mp4" >&2
+  echo "        - Hoặc chạy: ./run_all.sh đường/dẫn/tới/video.mp4" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- create the default `inputs/` directory and point the run scripts at its absolute path
- provide actionable error messaging when the default `input.mp4` is missing
- document how to supply the source video via a new `python-be/inputs/README.md`

## Testing
- bash run_all.sh *(fails: no input.mp4 provided, confirms new guidance)*

------
https://chatgpt.com/codex/tasks/task_b_68dfd412d2dc832caf15447e29c4f121