### PR TITLE
feat: add silence-aware transitions and new remotion effects

### DIFF
--- a/remotion-app/README.md
+++ b/remotion-app/README.md
@@ -26,15 +26,28 @@ Launches Remotion Studio so you can scrub through the composition, tweak props, 
 
 ### Render a video
 ```console
-npx remotion render
+npm run render
 ```
-Produces the final output in `out/` using the default composition.
+Produces the final output in `out/` using the default composition. Pass custom props (for example, a different plan path or min-pause override) with the `--props` flag:
+
+```console
+npm run render -- --props '{"planPath":"public/input/plan.json","config":{"minPauseMs":800}}'
+```
+
+The render/build commands rely on the locally installed Remotion CLI, so make sure `npm install` has been executed first.
 
 ### Upgrade Remotion
 ```console
 npx remotion upgrade
 ```
 Fetches the latest compatible Remotion version.
+
+## Runtime configuration
+
+- `src/config.ts` centralizes the audio and transition defaults exposed to the renderer. You can override these values at render time by passing a `config` object through `--props` (see the render example above).
+- Transition logic only fires when `silenceAfter` is `true` on a segment, so upstream planners should compute accurate silence windows.
+- The Remotion layer consumes the extended highlight set (`typewriter`, `noteBox`, `sectionTitle`, and `icon`) and will gracefully no-op unknown types.
+- B-roll placeholders (`segment.kind === "broll"`) render via `BrollPlaceholder` and can be swapped with real footage later without changing the plan contract.
 
 ## Documentation
 

--- a/remotion-app/package-lock.json
+++ b/remotion-app/package-lock.json
@@ -14,12 +14,15 @@
         "@remotion/renderer": "4.0.61",
         "@types/react": "18.2.47",
         "@types/react-dom": "18.2.17",
+        "lucide-react": "^0.544.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-icons": "^5.5.0",
         "remotion": "4.0.61",
         "zod": "3.23.8"
       },
       "devDependencies": {
+        "rimraf": "^6.0.1",
         "typescript": "5.3.3"
       }
     },
@@ -371,6 +374,47 @@
       "os": [
         "win32"
       ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -1030,6 +1074,32 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.10.tgz",
@@ -1124,6 +1194,26 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -1226,11 +1316,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.228",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.228.tgz",
       "integrity": "sha512-nxkiyuqAn4MJ1QbobwqJILiDtu/jk14hEAWaMiJmNPh1Z+jqoFlBFZjdXwLWGeVSeu9hGLg6+2G9yJaW8rBIFA==",
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -1440,6 +1544,36 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs-monkey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
@@ -1456,6 +1590,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -1515,6 +1673,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -1544,6 +1712,22 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -1666,6 +1850,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/memfs": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.3.tgz",
@@ -1714,11 +1907,37 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "license": "MIT"
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1809,6 +2028,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1816,6 +2042,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/pend": {
@@ -2002,6 +2255,15 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
@@ -2028,6 +2290,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {
@@ -2160,6 +2442,110 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-final-newline": {
@@ -2486,6 +2872,104 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/remotion-app/package.json
+++ b/remotion-app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "sync-assets": "node ./scripts/sync-assets.mjs",
+    "clean-sync": "rimraf ./public && node ./scripts/sync-assets.mjs",
     "prestart": "npm run sync-assets",
     "start": "remotion preview",
     "prebuild": "npm run sync-assets",
@@ -18,12 +19,15 @@
     "@remotion/renderer": "4.0.61",
     "@types/react": "18.2.47",
     "@types/react-dom": "18.2.17",
-    "remotion": "4.0.61",
+    "lucide-react": "^0.544.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^5.5.0",
+    "remotion": "4.0.61",
     "zod": "3.23.8"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "5.3.3"
   }
 }

--- a/remotion-app/scripts/sync-assets.mjs
+++ b/remotion-app/scripts/sync-assets.mjs
@@ -23,23 +23,21 @@ if (!existsSync(assetsDir)) {
 }
 
 const ensureDir = (dir) => {
-  mkdirSync(dir, {recursive: true});
+  mkdirSync(dir, { recursive: true });
 };
 
 const removePath = (targetPath) => {
-  if (!existsSync(targetPath)) {
-    return;
-  }
+  if (!existsSync(targetPath)) return;
 
-  const stats = lstatSync(targetPath);
-  if (stats.isDirectory() && !stats.isSymbolicLink()) {
-    rmSync(targetPath, {recursive: true, force: true});
-  } else {
-    rmSync(targetPath, {force: true});
+  try {
+    rmSync(targetPath, { recursive: true, force: true });
+  } catch (err) {
+    console.warn(`[removePath] Failed to remove ${targetPath}:`, err.message);
   }
 };
 
-const ensureLinkWithFallback = (source, destination, {label, fallbackCopy}) => {
+
+const ensureLinkWithFallback = (source, destination, { label, fallbackCopy }) => {
   removePath(destination);
   try {
     symlinkSync(source, destination, linkType);
@@ -47,21 +45,27 @@ const ensureLinkWithFallback = (source, destination, {label, fallbackCopy}) => {
     return true;
   } catch (error) {
     console.warn(
-      `[${label}] Failed to create symlink: ${error instanceof Error ? error.message : String(error)}`,
+      `[${label}] Failed to create symlink: ${
+        error instanceof Error ? error.message : String(error)
+      }`
     );
-    if (!fallbackCopy) {
-      return false;
-    }
-    cpSync(source, destination, {recursive: true});
+    if (!fallbackCopy) return false;
+
+    cpSync(source, destination, { recursive: true });
     console.log(`[${label}] Copied contents into ${destination}`);
     return false;
   }
 };
 
+// Bảo đảm thư mục tồn tại
 ensureDir(sharedPublicDir);
 ensureDir(sharedInputDir);
 
-ensureLinkWithFallback(assetsDir, sharedAssetsLink, {label: 'assets', fallbackCopy: true});
+// Tạo symlink hoặc fallback copy
+ensureLinkWithFallback(assetsDir, sharedAssetsLink, {
+  label: 'assets',
+  fallbackCopy: true,
+});
 const linkedPublic = ensureLinkWithFallback(sharedPublicDir, appPublicDir, {
   label: 'public',
   fallbackCopy: true,
@@ -69,6 +73,6 @@ const linkedPublic = ensureLinkWithFallback(sharedPublicDir, appPublicDir, {
 
 if (!linkedPublic) {
   console.log(
-    `[public] Using a copied public workspace. Keep in mind updates under ${sharedPublicDir} will not auto-sync.`,
+    `[public] Using a copied public workspace. Keep in mind updates under ${sharedPublicDir} will not auto-sync.`
   );
 }

--- a/remotion-app/src/Root.tsx
+++ b/remotion-app/src/Root.tsx
@@ -27,6 +27,7 @@ export const RemotionRoot: React.FC = () => {
           accentColor: '#38bdf8',
           fontFamily: 'Inter, sans-serif',
         },
+        config: {},
       }}
     />
   );

--- a/remotion-app/src/components/BrollPlaceholder.tsx
+++ b/remotion-app/src/components/BrollPlaceholder.tsx
@@ -1,0 +1,84 @@
+import {AbsoluteFill} from 'remotion';
+import type {CSSProperties} from 'react';
+import {BRAND} from '../config';
+
+export type BrollPlaceholderVariant = 'fullwidth' | 'roundedFrame';
+
+interface BrollPlaceholderProps {
+  title: string;
+  subtitle?: string;
+  variant?: BrollPlaceholderVariant;
+}
+
+export const BrollPlaceholder: React.FC<BrollPlaceholderProps> = ({
+  title,
+  subtitle,
+  variant = 'fullwidth',
+}) => {
+  const isRounded = variant === 'roundedFrame';
+
+  const background =
+    variant === 'fullwidth'
+      ? `radial-gradient(circle at 10% 10%, rgba(255,255,255,0.08), transparent 55%), ${BRAND.black}`
+      : BRAND.black;
+
+  const frameStyle: CSSProperties = {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: isRounded ? '8%' : '6%',
+    background,
+  };
+
+  const contentStyle: CSSProperties = {
+    width: '100%',
+    height: '100%',
+    borderRadius: isRounded ? 32 : 24,
+    border: '2px solid rgba(255,255,255,0.18)',
+    background:
+      variant === 'fullwidth'
+        ? `linear-gradient(135deg, rgba(25,25,35,0.92) 0%, rgba(12,12,18,0.92) 100%)`
+        : `linear-gradient(135deg, ${BRAND.red} 0%, #ff2748 100%)`,
+    boxShadow: '0 34px 120px rgba(0,0,0,0.45)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: BRAND.white,
+    textAlign: 'center',
+    padding: '6% 10%',
+  };
+
+  return (
+    <AbsoluteFill style={frameStyle}>
+      <div style={contentStyle}>
+        <div
+          style={{
+            fontSize: 88,
+            fontWeight: 700,
+            lineHeight: 1.05,
+            letterSpacing: 1.2,
+            textTransform: 'uppercase',
+          }}
+        >
+          {title}
+        </div>
+        {subtitle ? (
+          <div
+            style={{
+              marginTop: 24,
+              fontSize: 42,
+              opacity: 0.8,
+              maxWidth: '70%',
+              lineHeight: 1.4,
+            }}
+          >
+            {subtitle}
+          </div>
+        ) : null}
+      </div>
+    </AbsoluteFill>
+  );
+};

--- a/remotion-app/src/components/HighlightCallout.tsx
+++ b/remotion-app/src/components/HighlightCallout.tsx
@@ -1,6 +1,6 @@
 import {interpolate, useCurrentFrame, useVideoConfig} from 'remotion';
 import type {HighlightPlan, HighlightTheme} from '../types';
-import {renderHighlightVariant} from './TextHighlightVariants';
+import {renderHighlightByType} from './TextHighlightVariants';
 
 export interface HighlightCalloutProps {
   highlight: HighlightPlan;
@@ -34,14 +34,11 @@ export const HighlightCallout: React.FC<HighlightCalloutProps> = ({
     }
   );
 
-  const animation = highlight.animation ?? 'fade';
-  const content = renderHighlightVariant({
+  const content = renderHighlightByType({
     highlight,
     theme,
     appear,
     exit,
-    animation,
-    variant: highlight.variant,
     width,
     height,
   });

--- a/remotion-app/src/components/HighlightsLayer.tsx
+++ b/remotion-app/src/components/HighlightsLayer.tsx
@@ -1,6 +1,7 @@
 import {AbsoluteFill, Sequence} from 'remotion';
 import type {HighlightPlan, HighlightTheme} from '../types';
 import {HighlightCallout} from './HighlightCallout';
+import {IconEffect} from './IconEffect';
 
 interface HighlightsLayerProps {
   highlights: HighlightPlan[];
@@ -14,9 +15,14 @@ export const HighlightsLayer: React.FC<HighlightsLayerProps> = ({highlights, fps
       {highlights.map((highlight) => {
         const from = Math.round(highlight.start * fps);
         const duration = Math.max(1, Math.round(highlight.duration * fps));
+        const isIcon = (highlight.type ?? 'noteBox') === 'icon';
         return (
           <Sequence key={highlight.id} from={from} durationInFrames={duration} name={`highlight-${highlight.id}`}>
-            <HighlightCallout highlight={highlight} durationInFrames={duration} theme={theme} />
+            {isIcon ? (
+              <IconEffect highlight={highlight} durationInFrames={duration} theme={theme} />
+            ) : (
+              <HighlightCallout highlight={highlight} durationInFrames={duration} theme={theme} />
+            )}
           </Sequence>
         );
       })}

--- a/remotion-app/src/components/IconEffect.tsx
+++ b/remotion-app/src/components/IconEffect.tsx
@@ -1,0 +1,104 @@
+import {useMemo} from 'react';
+import {AbsoluteFill, Img, spring, staticFile, useCurrentFrame, useVideoConfig} from 'remotion';
+import type {CSSProperties, ReactNode} from 'react';
+import type {HighlightPlan, HighlightTheme} from '../types';
+import {BRAND} from '../config';
+import {getIconByName} from '../icons/lucide';
+
+const POSITION_STYLE = {
+  top: {justifyContent: 'flex-start', paddingTop: 140},
+  center: {justifyContent: 'center'},
+  bottom: {justifyContent: 'flex-end', paddingBottom: 140},
+} as const;
+
+interface IconEffectProps {
+  highlight: HighlightPlan;
+  durationInFrames: number;
+  theme?: HighlightTheme;
+}
+
+export const IconEffect: React.FC<IconEffectProps> = ({highlight, durationInFrames, theme}) => {
+  const frame = useCurrentFrame();
+  const {fps, width, height} = useVideoConfig();
+
+  const IconComponent = useMemo(() => getIconByName(highlight.name as string | undefined), [highlight.name]);
+  const assetSource = highlight.asset ? staticFile(highlight.asset) : null;
+
+  const progress = spring({
+    frame,
+    fps,
+    durationInFrames: Math.min(durationInFrames, Math.round(fps * 0.6)),
+    config: {
+      damping: 200,
+      stiffness: 130,
+      overshootClamping: false,
+    },
+  });
+
+  const settle = Math.min(1, frame / Math.max(1, durationInFrames));
+  const floatOffset = Math.sin((frame / fps) * Math.PI * 1.6) * 4 * (1 - Math.min(1, settle * 1.2));
+
+  const baseScale = 0.86 + progress * 0.18;
+  const glowOpacity = 0.35 + progress * 0.35;
+
+  const containerStyle = {
+    position: 'absolute' as const,
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '0 6%',
+    pointerEvents: 'none' as const,
+    color: theme?.textColor ?? BRAND.white,
+    fontFamily: theme?.fontFamily ?? "'Inter Tight', 'Inter', sans-serif",
+    ...(POSITION_STYLE[highlight.position ?? 'center'] ?? POSITION_STYLE.center),
+  };
+
+  const bubbleSize = Math.min(width, height) * 0.22;
+
+  const iconWrapper: CSSProperties = {
+    width: bubbleSize,
+    height: bubbleSize,
+    borderRadius: '50%',
+    background:
+      theme?.backgroundColor ?? 'linear-gradient(135deg, rgba(28,28,36,0.95) 0%, rgba(12,12,18,0.95) 100%)',
+    border: `2px solid ${theme?.accentColor ?? BRAND.red}`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transform: `scale(${baseScale}) translateY(${floatOffset}px)`,
+    boxShadow: `0 24px 60px rgba(0,0,0,0.45), 0 0 46px rgba(255,255,255,${glowOpacity * 0.25})`,
+  };
+
+  let content: ReactNode = null;
+
+  if (assetSource) {
+    content = (
+      <Img
+        src={assetSource}
+        style={{width: '70%', height: '70%', objectFit: 'contain'}}
+        alt={highlight.name ?? 'icon'}
+      />
+    );
+  } else if (IconComponent) {
+    content = <IconComponent size={Math.round(bubbleSize * 0.55)} color={theme?.accentColor ?? '#fff'} />;
+  } else {
+    content = (
+      <div
+        style={{
+          width: '55%',
+          height: '55%',
+          borderRadius: '18%',
+          background: theme?.accentColor ?? BRAND.red,
+          opacity: 0.85,
+        }}
+      />
+    );
+  }
+
+  return (
+    <AbsoluteFill style={containerStyle}>
+      <div style={iconWrapper}>{content}</div>
+    </AbsoluteFill>
+  );
+};

--- a/remotion-app/src/components/IconEffect.tsx
+++ b/remotion-app/src/components/IconEffect.tsx
@@ -4,6 +4,7 @@ import type {CSSProperties, ReactNode} from 'react';
 import type {HighlightPlan, HighlightTheme} from '../types';
 import {BRAND} from '../config';
 import {getIconByName} from '../icons/lucide';
+import * as React from 'react';
 
 const POSITION_STYLE = {
   top: {justifyContent: 'flex-start', paddingTop: 140},

--- a/remotion-app/src/components/SfxLayer.tsx
+++ b/remotion-app/src/components/SfxLayer.tsx
@@ -1,6 +1,8 @@
 import {Audio, Sequence, staticFile} from 'remotion';
 import {SFX_CATALOG} from '../data/sfxCatalog';
 import type {HighlightPlan} from '../types';
+import type {TimelineSegment} from './timeline';
+import type {RuntimeConfig} from '../config';
 
 const SFX_LOOKUP = (() => {
   const entries = new Map<string, string>();
@@ -84,35 +86,152 @@ const normalizeSfx = (value: string | undefined | null): string | null => {
   return `assets/sfx/${sanitized}`;
 };
 
-interface SfxLayerProps {
-  highlights: HighlightPlan[];
-  fps: number;
+const dbToGain = (db: number) => Math.pow(10, db / 20);
+
+interface SfxEvent {
+  id: string;
+  startFrame: number;
+  durationInFrames: number;
+  src: string;
+  gainDb?: number;
+  ducking: boolean;
 }
 
-export const SfxLayer: React.FC<SfxLayerProps> = ({highlights, fps}) => {
+const eventFromHighlight = (
+  highlight: HighlightPlan,
+  fps: number
+): Pick<SfxEvent, 'startFrame' | 'durationInFrames' | 'gainDb' | 'ducking'> => {
+  const startFrame = Math.round(highlight.start * fps);
+  const durationInFrames = Math.max(1, Math.round(highlight.duration * fps));
+  let gainDb = highlight.gain;
+  if (gainDb == null && typeof highlight.volume === 'number' && highlight.volume > 0) {
+    gainDb = 20 * Math.log10(highlight.volume);
+  }
+
+  return {
+    startFrame,
+    durationInFrames,
+    gainDb,
+    ducking: highlight.ducking !== false,
+  };
+};
+
+const collectTransitionEvents = (
+  timeline: TimelineSegment[],
+  fps: number
+): SfxEvent[] => {
+  const events: SfxEvent[] = [];
+
+  timeline.forEach((segment, index) => {
+    const plan = segment.segment;
+    const transition = plan.transitionOut;
+    if (!transition?.sfx) {
+      return;
+    }
+    const startFrame = segment.from + Math.max(0, segment.duration - segment.transitionOutFrames);
+    const durationSeconds = transition.duration ?? segment.transitionOutFrames / fps;
+    const durationInFrames = Math.max(1, Math.round(durationSeconds * fps));
+    const normalized = normalizeSfx(transition.sfx);
+    if (!normalized) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(`Could not resolve transition SFX asset for segment ${plan.id}`);
+      }
+      return;
+    }
+
+    events.push({
+      id: `${plan.id}-transition-${index}`,
+      startFrame,
+      durationInFrames,
+      src: normalized,
+      ducking: false,
+    });
+  });
+
+  return events;
+};
+
+const collectHighlightEvents = (highlights: HighlightPlan[], fps: number): SfxEvent[] => {
+  const events: SfxEvent[] = [];
+
+  highlights.forEach((highlight) => {
+    if (!highlight.sfx) {
+      return;
+    }
+    const normalized = normalizeSfx(highlight.sfx);
+    if (!normalized) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(`Could not resolve SFX asset for highlight ${highlight.id}`);
+      }
+      return;
+    }
+
+    const timings = eventFromHighlight(highlight, fps);
+    events.push({
+      id: `highlight-${highlight.id}`,
+      src: normalized,
+      ...timings,
+    });
+  });
+
+  return events;
+};
+
+const buildVolumeEnvelope = (
+  event: SfxEvent,
+  audioConfig: RuntimeConfig['audio'],
+  fps: number
+) => {
+  const baseDb = event.gainDb ?? audioConfig.sfxBaseGainDb;
+  const baseGain = Math.min(dbToGain(baseDb), dbToGain(-6));
+  const duckGain = dbToGain(audioConfig.voiceDuckDb);
+  const attackFrames = Math.max(1, Math.round(fps * 0.3));
+  const releaseFrames = Math.max(1, Math.round(fps * 0.3));
+  const fadeInFrames = Math.max(1, Math.round(fps * 0.12));
+  const fadeOutFrames = Math.max(1, Math.round(fps * 0.16));
+
+  return (frame: number) => {
+    const duckProgress = Math.min(frame / attackFrames, 1);
+    const fadeIn = Math.min(frame / fadeInFrames, 1);
+    const fadeOut = Math.min((event.durationInFrames - frame) / fadeOutFrames, 1);
+    const release = Math.min((event.durationInFrames - frame) / releaseFrames, 1);
+    const duckMultiplier = event.ducking ? duckGain + (1 - duckGain) * duckProgress : 1;
+    const amplitude = baseGain * duckMultiplier * fadeIn * Math.max(0, fadeOut) * Math.max(0, release);
+    return Math.min(amplitude, dbToGain(-6));
+  };
+};
+
+interface SfxLayerProps {
+  highlights: HighlightPlan[];
+  timeline: TimelineSegment[];
+  fps: number;
+  audioConfig: RuntimeConfig['audio'];
+}
+
+export const SfxLayer: React.FC<SfxLayerProps> = ({highlights, timeline, fps, audioConfig}) => {
+  const events = [...collectHighlightEvents(highlights, fps), ...collectTransitionEvents(timeline, fps)].sort(
+    (a, b) => a.startFrame - b.startFrame
+  );
+
   return (
     <>
-      {highlights
-        .filter((highlight) => highlight.sfx)
-        .map((highlight) => {
-          const from = Math.round(highlight.start * fps);
-          const duration = Math.max(1, Math.round(highlight.duration * fps));
-          const volume = highlight.volume ?? 0.7;
-          const resolved = normalizeSfx(highlight.sfx);
-          if (!resolved) {
-            if (process.env.NODE_ENV !== 'production') {
-              console.warn(`Could not resolve SFX asset for: ${highlight.sfx}`);
-            }
-            return null;
-          }
-
-          const src = staticFile(resolved);
-          return (
-            <Sequence key={`sfx-${highlight.id}`} from={from} durationInFrames={duration} name={`sfx-${highlight.id}`}>
-              <Audio src={src} volume={volume} />
-            </Sequence>
-          );
-        })}
+      {events.map((event) => {
+        const resolved = normalizeSfx(event.src);
+        if (!resolved) {
+          return null;
+        }
+        const src = staticFile(resolved);
+        return (
+          <Sequence
+            key={`sfx-${event.id}`}
+            from={event.startFrame}
+            durationInFrames={event.durationInFrames}
+            name={`sfx-${event.id}`}
+          >
+            <Audio src={src} volume={buildVolumeEnvelope(event, audioConfig, fps)} />
+          </Sequence>
+        );
+      })}
     </>
   );
 };

--- a/remotion-app/src/config.ts
+++ b/remotion-app/src/config.ts
@@ -1,6 +1,91 @@
+import type {CompositionConfigOverrides} from './types';
+
 export const VIDEO_WIDTH = 1920;
 export const VIDEO_HEIGHT = 1080;
 export const VIDEO_FPS = 30;
 
 const fallbackDurationSeconds = 15 * 60; // 15 minutes default cap
 export const DEFAULT_DURATION_IN_FRAMES = VIDEO_FPS * fallbackDurationSeconds;
+
+export const AUDIO = {
+  voiceDuckDb: -4,
+  sfxBaseGainDb: -10,
+};
+
+export const TRANSITIONS = {
+  minPauseMs: 700,
+  defaultFade: 0.8,
+};
+
+export const BRAND = {
+  red: '#C8102E',
+  black: '#1C1C1C',
+  white: '#fff',
+};
+
+export interface RuntimeConfig {
+  audio: typeof AUDIO;
+  transitions: typeof TRANSITIONS;
+  brand: typeof BRAND;
+}
+
+const clampNumber = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const normalizeNumber = (input: unknown, fallback: number, {min, max}: {min?: number; max?: number} = {}) => {
+  const numeric = Number(input);
+  if (Number.isNaN(numeric)) {
+    return fallback;
+  }
+  if (typeof min === 'number' || typeof max === 'number') {
+    return clampNumber(
+      numeric,
+      typeof min === 'number' ? min : numeric,
+      typeof max === 'number' ? max : numeric
+    );
+  }
+  return numeric;
+};
+
+export const resolveRuntimeConfig = (
+  overrides: CompositionConfigOverrides | undefined | null
+): RuntimeConfig => {
+  const audio = {
+    ...AUDIO,
+    ...(overrides?.audio ?? {}),
+  } as typeof AUDIO;
+
+  audio.voiceDuckDb = normalizeNumber(audio.voiceDuckDb, AUDIO.voiceDuckDb, {min: -24, max: 0});
+  audio.sfxBaseGainDb = normalizeNumber(audio.sfxBaseGainDb, AUDIO.sfxBaseGainDb, {min: -36, max: -1});
+
+  const transitions = {
+    ...TRANSITIONS,
+    ...(overrides?.transitions ?? {}),
+  } as typeof TRANSITIONS;
+
+  const explicitMinPause = overrides?.minPauseMs;
+  if (typeof explicitMinPause === 'number' && !Number.isNaN(explicitMinPause)) {
+    transitions.minPauseMs = clampNumber(explicitMinPause, 0, 4000);
+  } else {
+    transitions.minPauseMs = normalizeNumber(transitions.minPauseMs, TRANSITIONS.minPauseMs, {
+      min: 0,
+      max: 4000,
+    });
+  }
+
+  transitions.defaultFade = normalizeNumber(transitions.defaultFade, TRANSITIONS.defaultFade, {
+    min: 0.3,
+    max: 2.4,
+  });
+
+  const brand = {
+    ...BRAND,
+    ...(overrides?.brand ?? {}),
+  } as typeof BRAND;
+
+  return {
+    audio,
+    transitions,
+    brand,
+  };
+};

--- a/remotion-app/src/icons/lucide.tsx
+++ b/remotion-app/src/icons/lucide.tsx
@@ -1,0 +1,96 @@
+import type {FC, ReactNode} from 'react';
+
+export type IconComponent = FC<{
+  size?: number;
+  color?: string;
+  strokeWidth?: number;
+}>;
+
+const createIcon = (nodes: ReactNode[]): IconComponent => {
+  const Icon: IconComponent = ({size = 48, color = 'currentColor', strokeWidth = 1.8}) => (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {nodes}
+    </svg>
+  );
+  Icon.displayName = 'LucideIcon';
+  return Icon;
+};
+
+const Rocket = createIcon([
+  <path
+    key="body"
+    d="M12 2C9.2 4.5 7.5 7.9 7.5 11.2V14l-1.8 1.8 2.6.6.6 2.6 1.8-1.8H14c3.3 0 6.1-1.4 8.2-3.5C20.8 8 17.5 4.6 12 2Z"
+  />,
+  <circle key="window" cx="12" cy="9" r="1.4" />,
+  <path key="flame" d="M9.8 19c.5 1.3 1.6 2.4 2.2 2.7.6-.3 1.7-1.4 2.2-2.7" />,
+]);
+
+const Sparkles = createIcon([
+  <path key="large" d="M12 11l1.4 4.2 4.2 1.4-4.2 1.4-1.4 4.2-1.4-4.2-4.2-1.4 4.2-1.4Z" />,
+  <path key="small" d="M5 3.2l.7 2.2 2.2.7-2.2.7-.7 2.2-.7-2.2-2.2-.7 2.2-.7Z" />,
+  <path key="top" d="M18 4l.6 1.7 1.7.6-1.7.6-.6 1.7-.6-1.7-1.7-.6 1.7-.6Z" />,
+]);
+
+const Target = createIcon([
+  <circle key="outer" cx="12" cy="12" r="8" />,
+  <circle key="mid" cx="12" cy="12" r="4.8" />,
+  <circle key="inner" cx="12" cy="12" r="2" />,
+  <path key="arrow" d="M18 6 21 3" />,
+]);
+
+const Lightbulb = createIcon([
+  <path key="bulb" d="M9 10a3 3 0 1 1 6 0c0 2-1.2 3.5-3 5-1.8-1.5-3-3-3-5Z" />,
+  <path key="base" d="M10 17h4" />,
+  <path key="stem" d="M10.5 20h3" />,
+]);
+
+const TrendingUp = createIcon([
+  <path key="line" d="M3 17l6-6 4 4 7-7" />,
+  <path key="arrow" d="M18 8h3v3" />,
+]);
+
+const Star = createIcon([
+  <path key="star" d="M12 4l2 4.6 5 .7-3.8 3.4.9 5-4.1-2.3-4.1 2.3.9-5-3.8-3.4 5-.7Z" />,
+]);
+
+const CheckCircle = createIcon([
+  <circle key="circle" cx="12" cy="12" r="8.5" />,
+  <path key="check" d="m9 12 2 2 4-4" />,
+]);
+
+const IconMap: Record<string, IconComponent> = {
+  Rocket,
+  Sparkles,
+  Target,
+  Lightbulb,
+  TrendingUp,
+  Star,
+  CheckCircle,
+};
+
+export const getIconByName = (name: string | undefined): IconComponent | null => {
+  if (!name) {
+    return null;
+  }
+  const direct = IconMap[name];
+  if (direct) {
+    return direct;
+  }
+  const normalized = name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join('');
+  return IconMap[normalized] ?? null;
+};
+
+export const iconNames = Object.keys(IconMap);

--- a/remotion-app/src/icons/lucide.tsx
+++ b/remotion-app/src/icons/lucide.tsx
@@ -1,4 +1,5 @@
 import type {FC, ReactNode} from 'react';
+import * as React from 'react';
 
 export type IconComponent = FC<{
   size?: number;

--- a/remotion-app/src/types.ts
+++ b/remotion-app/src/types.ts
@@ -1,11 +1,4 @@
-export type TransitionType =
-  | 'cut'
-  | 'crossfade'
-  | 'slide'
-  | 'zoom'
-  | 'scale'
-  | 'rotate'
-  | 'blur';
+export type TransitionType = 'cut' | 'fadeCamera' | 'slideWhoosh';
 
 export type TransitionDirection = 'left' | 'right' | 'up' | 'down';
 
@@ -13,51 +6,58 @@ export interface TransitionPlan {
   type: TransitionType;
   duration?: number;
   direction?: TransitionDirection;
-  intensity?: number;
+  sfx?: string;
 }
+
+export type SegmentKind = 'normal' | 'broll';
 
 export type CameraMovement = 'static' | 'zoomIn' | 'zoomOut';
 
 export interface SegmentPlan {
   id: string;
-  sourceStart: number;
+  kind?: SegmentKind;
+  sourceStart?: number;
   duration: number;
   transitionIn?: TransitionPlan;
   transitionOut?: TransitionPlan;
   label?: string;
+  title?: string;
   playbackRate?: number;
   cameraMovement?: CameraMovement;
+  silenceAfter?: boolean;
   metadata?: Record<string, unknown>;
 }
 
+export type HighlightType = 'typewriter' | 'noteBox' | 'sectionTitle' | 'icon';
+
 export type HighlightPosition = 'top' | 'center' | 'bottom';
-
-export type HighlightAnimation =
-  | 'fade'
-  | 'zoom'
-  | 'slide'
-  | 'bounce'
-  | 'float'
-  | 'flip'
-  | 'typewriter';
-
-export type HighlightVariant = 'callout' | 'blurred' | 'cutaway' | 'brand' | 'typewriter';
 
 export interface HighlightPlan {
   id: string;
-  text: string;
+  type?: HighlightType;
+  text?: string;
+  title?: string;
+  subtitle?: string;
+  badge?: string;
+  name?: string;
+  asset?: string;
   start: number;
   duration: number;
   position?: HighlightPosition;
-  animation?: HighlightAnimation;
+  side?: 'bottom' | 'left' | 'right' | 'top';
+  bg?: string;
+  radius?: number;
   sfx?: string;
-  volume?: number;
-  variant?: HighlightVariant;
+  gain?: number;
+  ducking?: boolean;
+  variant?: string;
+  [key: string]: unknown;
 }
 
 export interface Plan {
   segments: SegmentPlan[];
   highlights: HighlightPlan[];
+  meta?: Record<string, unknown>;
 }
 
 export interface HighlightTheme {
@@ -67,10 +67,18 @@ export interface HighlightTheme {
   fontFamily?: string;
 }
 
+export interface CompositionConfigOverrides {
+  minPauseMs?: number;
+  audio?: Partial<{voiceDuckDb: number; sfxBaseGainDb: number}>;
+  transitions?: Partial<{defaultFade: number}>;
+  brand?: Partial<{red: string; black: string; white: string}>;
+}
+
 export interface FinalCompositionProps {
   plan?: Plan | null;
   planPath?: string;
   inputVideo?: string;
   fallbackTransitionDuration?: number;
   highlightTheme?: HighlightTheme;
+  config?: CompositionConfigOverrides;
 }


### PR DESCRIPTION
## Summary
- Load silence thresholds from the environment when generating plans, tag segment gaps, and emit highlight types for downstream rendering.
- Extend shared config and plan schemas with new transition, highlight, and segment metadata so Remotion can react to silence-only transitions and b-roll placeholders.
- Implement refreshed highlight variants, icon animations, b-roll placeholders, and ducked SFX handling with custom transition logic and runtime configuration wiring.

## Testing
- `npm run build` *(fails: remotion CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68e00055e84c832ca37fbbb25bbf8552