### PR TITLE
Enhance b-roll placeholders with keywords and icons

### DIFF
--- a/remotion-app/src/components/BrollPlaceholder.tsx
+++ b/remotion-app/src/components/BrollPlaceholder.tsx
@@ -1,5 +1,7 @@
-import {AbsoluteFill} from 'remotion';
+import {AbsoluteFill, useCurrentFrame, useVideoConfig} from 'remotion';
 import type {CSSProperties} from 'react';
+import {Clapperboard, Image as ImageIcon, Sparkles} from 'lucide-react';
+import {PiMusicNotesBold} from 'react-icons/pi';
 import {BRAND} from '../config';
 
 export type BrollPlaceholderVariant = 'fullwidth' | 'roundedFrame';
@@ -8,13 +10,25 @@ interface BrollPlaceholderProps {
   title: string;
   subtitle?: string;
   variant?: BrollPlaceholderVariant;
+  keyword?: string;
+  mediaType?: 'image' | 'video';
 }
 
 export const BrollPlaceholder: React.FC<BrollPlaceholderProps> = ({
   title,
   subtitle,
   variant = 'fullwidth',
+  keyword,
+  mediaType = 'video',
 }) => {
+  const frame = useCurrentFrame();
+  const {fps} = useVideoConfig();
+  const safeFps = Math.max(fps, 1);
+  const loopProgress = (frame / safeFps) % 1;
+  const floatOffset = Math.sin(loopProgress * Math.PI * 2) * 10;
+  const pulseScale = 1 + Math.sin(loopProgress * Math.PI * 2) * 0.045;
+  const sparkleOpacity = 0.45 + Math.sin(loopProgress * Math.PI * 2) * 0.25;
+
   const isRounded = variant === 'roundedFrame';
 
   const background =
@@ -49,35 +63,126 @@ export const BrollPlaceholder: React.FC<BrollPlaceholderProps> = ({
     color: BRAND.white,
     textAlign: 'center',
     padding: '6% 10%',
+    position: 'relative',
   };
+
+  const keywordText = (keyword ?? title ?? 'keyword').toString().trim() || 'keyword';
+  const descriptor = `Broll - ${mediaType.toLowerCase()} - ${keywordText}`;
+
+  const descriptorStyle: CSSProperties = {
+    fontSize: 68,
+    fontWeight: 800,
+    lineHeight: 1.05,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    textShadow: '0 12px 32px rgba(0,0,0,0.65)',
+  };
+
+  const hintStyle: CSSProperties = {
+    marginTop: 18,
+    fontSize: 30,
+    opacity: 0.75,
+    maxWidth: '80%',
+    lineHeight: 1.35,
+  };
+
+  const chipRowStyle: CSSProperties = {
+    marginTop: 36,
+    display: 'flex',
+    gap: 18,
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  };
+
+  const chipStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    background: 'rgba(255,255,255,0.08)',
+    border: '1px solid rgba(255,255,255,0.18)',
+    borderRadius: 999,
+    padding: '10px 20px',
+    fontSize: 24,
+    fontWeight: 500,
+    letterSpacing: 0.4,
+  };
+
+  const mediaIcon =
+    mediaType === 'image' ? (
+      <ImageIcon size={96} color={BRAND.white} strokeWidth={1.8} />
+    ) : (
+      <Clapperboard size={96} color={BRAND.white} strokeWidth={1.8} />
+    );
 
   return (
     <AbsoluteFill style={frameStyle}>
       <div style={contentStyle}>
         <div
           style={{
-            fontSize: 88,
-            fontWeight: 700,
-            lineHeight: 1.05,
-            letterSpacing: 1.2,
-            textTransform: 'uppercase',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 26,
           }}
         >
-          {title}
-        </div>
-        {subtitle ? (
           <div
             style={{
-              marginTop: 24,
-              fontSize: 42,
-              opacity: 0.8,
-              maxWidth: '70%',
-              lineHeight: 1.4,
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 156,
+              height: 156,
+              borderRadius: '50%',
+              background:
+                variant === 'fullwidth'
+                  ? 'linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.05) 100%)'
+                  : 'linear-gradient(135deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.1) 100%)',
+              boxShadow: '0 24px 64px rgba(0,0,0,0.45)',
+              transform: `translateY(${floatOffset}px) scale(${pulseScale})`,
+              transition: 'transform 0.3s ease-out',
             }}
           >
-            {subtitle}
+            {mediaIcon}
+            <Sparkles
+              size={38}
+              color={BRAND.red}
+              strokeWidth={1.6}
+              style={{
+                position: 'absolute',
+                top: 16,
+                right: 12,
+                opacity: sparkleOpacity,
+                transform: 'rotate(-8deg)',
+              }}
+            />
           </div>
-        ) : null}
+          <div style={descriptorStyle}>{descriptor}</div>
+          {title ? (
+            <div style={hintStyle}>{title}</div>
+          ) : null}
+          {subtitle ? (
+            <div
+              style={{
+                ...hintStyle,
+                fontSize: 26,
+                opacity: 0.65,
+              }}
+            >
+              {subtitle}
+            </div>
+          ) : null}
+          <div style={chipRowStyle}>
+            <div style={chipStyle}>
+              <Sparkles size={22} strokeWidth={1.8} />
+              Chờ tải b-roll phù hợp
+            </div>
+            <div style={chipStyle}>
+              <PiMusicNotesBold size={24} />
+              Gợi ý thêm SFX sinh động
+            </div>
+          </div>
+        </div>
       </div>
     </AbsoluteFill>
   );


### PR DESCRIPTION
## Summary
- add keyword and media type extraction for b-roll segments so placeholders explain the missing asset
- redesign the b-roll placeholder to show the "Broll - type - keyword" guidance with animated lucide/react-icons visuals

## Testing
- npx tsc --noEmit *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e08ad1ccd8832cb8d4c3990b235e12