### PR TITLE
Normalize highlight type aliases

### DIFF
--- a/remotion-app/src/data/planSchema.ts
+++ b/remotion-app/src/data/planSchema.ts
@@ -97,8 +97,34 @@ const segmentPlanSchema: z.ZodType<SegmentPlan> = z
     } as SegmentPlan;
   });
 
+const normalizeHighlightTypeToken = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  const collapsed = trimmed.replace(/[\s_-]+/g, '');
+
+  switch (collapsed) {
+    case 'icon':
+    case 'iconhighlight':
+      return 'icon';
+    case 'notebox':
+      return 'noteBox';
+    case 'sectiontitle':
+      return 'sectionTitle';
+    case 'typewriter':
+      return 'typewriter';
+    default:
+      return value;
+  }
+};
+
 const highlightTypeSchema: z.ZodType<HighlightType> = z
-  .enum(['typewriter', 'noteBox', 'sectionTitle', 'icon'])
+  .preprocess(
+    normalizeHighlightTypeToken,
+    z.enum(['typewriter', 'noteBox', 'sectionTitle', 'icon']),
+  )
   .catch('noteBox');
 
 const highlightPositionSchema: z.ZodType<HighlightPosition> = z


### PR DESCRIPTION
## Summary
- add preprocessing for highlight type tokens so casing and separator variations resolve to canonical values
- map legacy icon highlight aliases to the icon highlight type while keeping existing fallbacks

## Testing
- `npm --prefix remotion-app run build` *(fails: Thorium download blocked in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e099fcc900832cb3e5081b71ee97d2