### PR TITLE
Normalize Gemini plan segment metadata

### DIFF
--- a/python-be/plan/sample_plan.json
+++ b/python-be/plan/sample_plan.json
@@ -1,0 +1,37 @@
+{
+  "segments": [
+    {
+      "id": "talk-1",
+      "sourceStart": 0.0,
+      "duration": 4.2,
+      "label": "Intro",
+      "silenceAfter": true,
+      "transitionOut": {
+        "type": "crossfade",
+        "duration": 0.5
+      }
+    },
+    {
+      "id": "broll-1",
+      "sourceStart": 4.2,
+      "duration": 3.5,
+      "kind": "broll",
+      "label": "City skyline",
+      "title": "City skyline",
+      "cameraMovement": "zoomIn",
+      "metadata": {
+        "subtitle": "B-roll city skyline",
+        "keyword": "city",
+        "cameraMovement": "zoom in"
+      }
+    },
+    {
+      "id": "talk-2",
+      "sourceStart": 7.8,
+      "duration": 5.0,
+      "kind": "normal",
+      "gapAfter": false
+    }
+  ],
+  "highlights": []
+}


### PR DESCRIPTION
## Summary
- copy optional segment metadata such as kind, title, silenceAfter, gapAfter, and metadata when normalizing Gemini plans
- normalize kind to the normal/broll taxonomy while forcing silenceAfter and gapAfter into booleans
- keep raw metadata dictionaries so B-roll placeholders receive subtitle/keyword context, with a sample normalized plan showing the behavior

## Testing
- python -m compileall python-be/scripts/make_plan_gemini.py
- python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_b_68e0a73ebb10832caed46f1b15cd98bf