### PR TITLE
Add configurable Auto-Editor trimming step

### DIFF
--- a/config/video_editing.json
+++ b/config/video_editing.json
@@ -1,0 +1,8 @@
+{
+  "auto_editor": {
+    "threshold": 0.06,
+    "margin": "0.75s,1s",
+    "silent_speed": 4,
+    "video_speed": 1
+  }
+}

--- a/python-be/README.md
+++ b/python-be/README.md
@@ -43,11 +43,13 @@ The scripts inside `python-be/` normalize your source footage, generate transcri
    run_all.bat                      # or run_all.bat path\to\video.mp4
    ```
 
-   The script performs the following:
-   - Auto-Editor removes silence → `outputs/stage1_cut.mp4`.
+  The script performs the following:
+   - Auto-Editor trims long pauses with a smooth-pace preset → `outputs/stage1_cut.mp4` (configurable via `config/video_editing.json`).
    - Whisper generates an SRT transcript → `outputs/stage1_cut.srt`.
    - A planning step produces `plan.json` (Gemini first, static mapping fallback).
-   - Copies `stage1_cut.mp4` and `plan.json` into `public/input/` as `input.mp4` and `plan.json`.
+   - Copies `stage1_cut.mp4` (or the original video if trimming is skipped) and `plan.json` into `public/input/` as `input.mp4` and `plan.json`.
+
+   > 💡 Tweak the trimming feel by editing `config/video_editing.json` (`threshold`, `margin`, `silent_speed`, `video_speed`). Use `./run_all.sh --autoedit false` (or `run_all.bat --autoedit=false`) to bypass Auto-Editor when you want the raw take.
 
 4. **Render with Remotion**
    ```bash

--- a/python-be/run_all.bat
+++ b/python-be/run_all.bat
@@ -1,12 +1,41 @@
 @echo off
-setlocal ENABLEEXTENSIONS
+setlocal ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 
 set "SCRIPT_DIR=%~dp0"
 cd /d "%SCRIPT_DIR%"
 
-:: Default input chuyển sang public\input thay vì python-be\inputs
+set "SOURCE_VIDEO=%SCRIPT_DIR%..\public\input\input.mp4"
+set "AUTOEDIT_ENABLED=true"
+
+:parse_args
+if "%~1"=="" goto after_args
+if /I "%~1"=="--autoedit" (
+  shift
+  if "%~1"=="" (
+    echo [ERROR] --autoedit requires a value (true/false)
+    exit /b 1
+  )
+  set "AUTOEDIT_ENABLED=%~1"
+  goto shift_args
+)
+for /f "tokens=1* delims==" %%A in ("%~1") do (
+  if /I "%%A"=="--autoedit" (
+    set "AUTOEDIT_ENABLED=%%B"
+    goto shift_args
+  )
+)
 set "SOURCE_VIDEO=%~1"
-if "%SOURCE_VIDEO%"=="" set "SOURCE_VIDEO=%SCRIPT_DIR%..\public\input\input.mp4"
+
+:shift_args
+shift
+goto parse_args
+
+:after_args
+for /f "delims=" %%I in ('python -c "import sys;print(sys.argv[1].lower())" "%AUTOEDIT_ENABLED%"') do set "AUTOEDIT_ENABLED=%%I"
+if /I not "%AUTOEDIT_ENABLED%"=="true" if /I not "%AUTOEDIT_ENABLED%"=="false" (
+  echo [ERROR] --autoedit expects true or false, got '%AUTOEDIT_ENABLED%'
+  exit /b 1
+)
 
 set "OUTPUT_DIR=%SCRIPT_DIR%outputs"
 set "PUBLIC_ROOT=%SCRIPT_DIR%..\public"
@@ -15,6 +44,7 @@ set "AUTO_EDITOR_OUTPUT=%OUTPUT_DIR%\stage1_cut.mp4"
 set "WHISPER_SRT=%OUTPUT_DIR%\stage1_cut.srt"
 set "PLAN_TMP=%OUTPUT_DIR%\plan.json"
 set "PLAN_MAPPING=%SCRIPT_DIR%plan\mapping.json"
+set "CONFIG_FILE=%SCRIPT_DIR%..\config\video_editing.json"
 
 if not exist "%SOURCE_VIDEO%" (
   echo [ERROR] Khong tim thay video dau vao: %SOURCE_VIDEO%
@@ -24,15 +54,53 @@ if not exist "%SOURCE_VIDEO%" (
 if not exist "%OUTPUT_DIR%" mkdir "%OUTPUT_DIR%"
 if not exist "%PUBLIC_INPUT%" mkdir "%PUBLIC_INPUT%"
 
-echo [STEP] Auto-Editor: loai bo khoang lang => %AUTO_EDITOR_OUTPUT%
-python -m auto_editor "%SOURCE_VIDEO%" -o "%AUTO_EDITOR_OUTPUT%" ^
-  --edit audio:threshold=0.04 ^
-  --video-codec libx264 ^
-  --audio-codec aac ^
-  --quiet
+for /f "tokens=1-4 delims=|" %%A in ('python scripts\read_autoedit_config.py "%CONFIG_FILE%"') do (
+  set "AUTOEDITOR_THRESHOLD=%%A"
+  set "AUTOEDITOR_MARGIN=%%B"
+  set "AUTOEDITOR_SILENT_SPEED=%%C"
+  set "AUTOEDITOR_VIDEO_SPEED=%%D"
+)
+if "%AUTOEDITOR_THRESHOLD%"=="" set "AUTOEDITOR_THRESHOLD=0.06"
+if "%AUTOEDITOR_MARGIN%"=="" set "AUTOEDITOR_MARGIN=0.75s,1s"
+if "%AUTOEDITOR_SILENT_SPEED%"=="" set "AUTOEDITOR_SILENT_SPEED=4"
+if "%AUTOEDITOR_VIDEO_SPEED%"=="" set "AUTOEDITOR_VIDEO_SPEED=1"
+
+set "SOURCE_FOR_TRANSCRIPTION=%SOURCE_VIDEO%"
+if /I "%AUTOEDIT_ENABLED%"=="true" (
+  echo 🎬 Auto-Editor trimming with smooth-pace preset…
+  python -c "import auto_editor" >nul 2>&1
+  if errorlevel 1 (
+    echo [INFO] Auto-Editor not found. Installing...
+    python -m pip install --quiet auto-editor
+    if errorlevel 1 (
+      echo [WARN] Failed to install Auto-Editor. Skipping trimming.
+      set "AUTOEDIT_ENABLED=false"
+    )
+  )
+
+  if /I "%AUTOEDIT_ENABLED%"=="true" (
+    set "AUTO_EDITOR_LOG=%OUTPUT_DIR%\auto_editor.log"
+    python -m auto_editor "%SOURCE_VIDEO%" ^
+      --output "%AUTO_EDITOR_OUTPUT%" ^
+      --edit "audio:threshold=%AUTOEDITOR_THRESHOLD%" ^
+      --margin "%AUTOEDITOR_MARGIN%" ^
+      --silent-speed "%AUTOEDITOR_SILENT_SPEED%" ^
+      --video-speed "%AUTOEDITOR_VIDEO_SPEED%" 1>"%AUTO_EDITOR_LOG%" 2>&1
+    if errorlevel 1 (
+      type "%AUTO_EDITOR_LOG%"
+      echo [WARN] Auto-Editor trimming failed. Using original video.
+    ) else (
+      type "%AUTO_EDITOR_LOG%"
+      set "SOURCE_FOR_TRANSCRIPTION=%AUTO_EDITOR_OUTPUT%"
+    )
+    if exist "%AUTO_EDITOR_LOG%" del "%AUTO_EDITOR_LOG%" >nul 2>&1
+  )
+) else (
+  echo [INFO] Auto-Editor trimming skipped via flag.
+)
 
 echo [STEP] Whisper: tao transcript SRT => %WHISPER_SRT%
-python -m whisper "%AUTO_EDITOR_OUTPUT%" ^
+python -m whisper "%SOURCE_FOR_TRANSCRIPTION%" ^
   --model small ^
   --language en ^
   --task transcribe ^
@@ -53,7 +121,13 @@ if errorlevel 1 (
   echo [INFO] Gemini plan generated successfully.
 )
 
-copy /Y "%AUTO_EDITOR_OUTPUT%" "%PUBLIC_INPUT%\input.mp4" >nul
+set "FINAL_VIDEO_PATH=%SOURCE_FOR_TRANSCRIPTION%"
+if /I not "%FINAL_VIDEO_PATH%"=="%AUTO_EDITOR_OUTPUT%" (
+  set "FINAL_VIDEO_PATH=%SOURCE_VIDEO%"
+  copy /Y "%SOURCE_VIDEO%" "%AUTO_EDITOR_OUTPUT%" >nul
+)
+
+copy /Y "%FINAL_VIDEO_PATH%" "%PUBLIC_INPUT%\input.mp4" >nul
 copy /Y "%PLAN_TMP%" "%PUBLIC_INPUT%\plan.json" >nul
 
 echo [DONE] Da copy du lieu sang public\input\

--- a/python-be/run_all.sh
+++ b/python-be/run_all.sh
@@ -5,7 +5,33 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 # ✅ Default input video nằm trong public/input thay vì python-be/inputs
-SOURCE_VIDEO="${1:-$SCRIPT_DIR/../public/input/input.mp4}"
+SOURCE_VIDEO="$SCRIPT_DIR/../public/input/input.mp4"
+AUTOEDIT_ENABLED="true"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --autoedit)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "[ERROR] --autoedit requires a value (true/false)" >&2
+        exit 1
+      fi
+      AUTOEDIT_ENABLED="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
+      ;;
+    --autoedit=*)
+      AUTOEDIT_ENABLED="$(echo "${1#--autoedit=}" | tr '[:upper:]' '[:lower:]')"
+      ;;
+    *)
+      SOURCE_VIDEO="$1"
+      ;;
+  esac
+  shift
+done
+
+if [[ "$AUTOEDIT_ENABLED" != "true" && "$AUTOEDIT_ENABLED" != "false" ]]; then
+  echo "[ERROR] --autoedit expects true or false, got '$AUTOEDIT_ENABLED'" >&2
+  exit 1
+fi
 
 OUTPUT_DIR="$SCRIPT_DIR/outputs"
 PUBLIC_ROOT="$SCRIPT_DIR/../public"
@@ -22,15 +48,56 @@ fi
 
 mkdir -p "$OUTPUT_DIR" "$PUBLIC_INPUT"
 
-echo "[STEP] Auto-Editor: loại bỏ khoảng lặng => $AUTO_EDITOR_OUTPUT"
-python -m auto_editor "$SOURCE_VIDEO" -o "$AUTO_EDITOR_OUTPUT" \
-  --edit audio:threshold=0.04 \
-  --video-codec libx264 \
-  --audio-codec aac \
-  --quiet
+# Read Auto-Editor configuration values (with defaults)
+CONFIG_FILE="$SCRIPT_DIR/../config/video_editing.json"
+CONFIG_SCRIPT="$SCRIPT_DIR/scripts/read_autoedit_config.py"
+IFS='|' read -r AUTOEDITOR_THRESHOLD AUTOEDITOR_MARGIN AUTOEDITOR_SILENT_SPEED AUTOEDITOR_VIDEO_SPEED < <(
+  python "$CONFIG_SCRIPT" "$CONFIG_FILE"
+)
+AUTOEDITOR_THRESHOLD=${AUTOEDITOR_THRESHOLD:-0.06}
+AUTOEDITOR_MARGIN=${AUTOEDITOR_MARGIN:-0.75s,1s}
+AUTOEDITOR_SILENT_SPEED=${AUTOEDITOR_SILENT_SPEED:-4}
+AUTOEDITOR_VIDEO_SPEED=${AUTOEDITOR_VIDEO_SPEED:-1}
+
+SOURCE_FOR_TRANSCRIPTION="$SOURCE_VIDEO"
+if [[ "$AUTOEDIT_ENABLED" != "false" ]]; then
+  echo "🎬 Auto-Editor trimming with smooth-pace preset…"
+
+  if ! python - <<'PY'
+try:
+    import auto_editor  # noqa: F401
+except ModuleNotFoundError:
+    raise SystemExit(1)
+PY
+  then
+    echo "[INFO] Auto-Editor not found. Installing..."
+    if ! python -m pip install --quiet auto-editor; then
+      echo "[WARN] Failed to install Auto-Editor. Skipping trimming." >&2
+      AUTOEDIT_ENABLED="false"
+    fi
+  fi
+
+  if [[ "$AUTOEDIT_ENABLED" != "false" ]]; then
+    if AUTO_EDITOR_LOG=$(python -m auto_editor "$SOURCE_VIDEO" \
+      --output "$AUTO_EDITOR_OUTPUT" \
+      --edit "audio:threshold=$AUTOEDITOR_THRESHOLD" \
+      --margin "$AUTOEDITOR_MARGIN" \
+      --silent-speed "$AUTOEDITOR_SILENT_SPEED" \
+      --video-speed "$AUTOEDITOR_VIDEO_SPEED" 2>&1); then
+      printf '%s\n' "$AUTO_EDITOR_LOG"
+      SOURCE_FOR_TRANSCRIPTION="$AUTO_EDITOR_OUTPUT"
+    else
+      printf '%s\n' "$AUTO_EDITOR_LOG" >&2
+      echo "[WARN] Auto-Editor trimming failed. Using original video." >&2
+      SOURCE_FOR_TRANSCRIPTION="$SOURCE_VIDEO"
+    fi
+  fi
+else
+  echo "[INFO] Auto-Editor trimming skipped via flag." >&2
+fi
 
 echo "[STEP] Whisper: tạo transcript SRT => $WHISPER_SRT"
-python -m whisper "$AUTO_EDITOR_OUTPUT" \
+python -m whisper "$SOURCE_FOR_TRANSCRIPTION" \
   --model small \
   --language en \
   --task transcribe \
@@ -51,7 +118,13 @@ else
 fi
 
 # ✅ Copy kết quả ngược lại public/input để Remotion đọc
-cp "$AUTO_EDITOR_OUTPUT" "$PUBLIC_INPUT/input.mp4"
+FINAL_VIDEO_PATH="$SOURCE_FOR_TRANSCRIPTION"
+if [[ "$FINAL_VIDEO_PATH" != "$AUTO_EDITOR_OUTPUT" ]]; then
+  FINAL_VIDEO_PATH="$SOURCE_VIDEO"
+  cp "$SOURCE_VIDEO" "$AUTO_EDITOR_OUTPUT"
+fi
+
+cp "$FINAL_VIDEO_PATH" "$PUBLIC_INPUT/input.mp4"
 cp "$PLAN_TMP" "$PUBLIC_INPUT/plan.json"
 
 echo "[DONE] Đã copy dữ liệu sang public/input/"

--- a/python-be/scripts/read_autoedit_config.py
+++ b/python-be/scripts/read_autoedit_config.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Read Auto-Editor configuration values for trimming presets."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+DEFAULTS = {
+    "threshold": "0.06",
+    "margin": "0.75s,1s",
+    "silent_speed": "4",
+    "video_speed": "1",
+}
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("|".join(DEFAULTS.values()), end="")
+        return
+
+    config_path = Path(sys.argv[1])
+    data: dict[str, object] = {}
+    try:
+        text = config_path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except Exception:
+        data = {}
+
+    auto_editor = data.get("auto_editor") if isinstance(data, dict) else {}
+    if not isinstance(auto_editor, dict):
+        auto_editor = {}
+
+    values = []
+    for key, default in DEFAULTS.items():
+        value = auto_editor.get(key, default)
+        values.append(str(value))
+
+    sys.stdout.write("|".join(values))
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a shared Auto-Editor config file and helper to expose threshold, margin, and speed presets
- update the bash and batch pipelines to auto-install/run Auto-Editor with smooth pacing and fallback handling
- document the new trimming behavior, config options, and --autoedit skip flag

## Testing
- python -m compileall python-be/scripts/read_autoedit_config.py

------
https://chatgpt.com/codex/tasks/task_b_68e0fb63357c832c99d6413be5ba0687